### PR TITLE
pygments_vulnerabilities

### DIFF
--- a/tests/pytest_tests/assets/wandb/offline-run-20210216_154407-g9dvvkua/files/requirements.txt
+++ b/tests/pytest_tests/assets/wandb/offline-run-20210216_154407-g9dvvkua/files/requirements.txt
@@ -221,7 +221,7 @@ pydoc-markdown==2.1.3
 pydot==1.4.1
 pyflakes==1.5.0
 pyglet==1.5.0
-pygments==2.2.0
+pygments==2.7.4
 pylint==1.7.4
 pymongo==3.10.1
 pynvx==1.0.0


### PR DESCRIPTION
Description
-----------
Vulnerabilities raised due to Pygments==2.2.0, need to upgrade to 2.7.4
The vulnerabilities are:
1.  CVE-2021-27291
2.  CVE-2021-20270

The version in the current vendor/pygments is 2.2.0.
Both vulnerabilities were fixed in 2.7.4

What does the PR do? Include a concise description of the PR contents.
